### PR TITLE
🐛 fix removing subscriptions on unsubscribe

### DIFF
--- a/src/faye.ts
+++ b/src/faye.ts
@@ -99,7 +99,6 @@ export class MessageBusService extends EventEmitter2 implements IMessageBusServi
           subscription.fayeSubscription.cancel();
         }
 
-        console.log(`mapping ${subscription.callback.toString()}`);
         const newSubscription: SubscriptionObject = this.fayeClient.subscribe(channel).withChannel(subscription.callback);
         this.subscriptions[channel].push({
           fayeSubscription: newSubscription,

--- a/src/faye.ts
+++ b/src/faye.ts
@@ -81,7 +81,7 @@ export class MessageBusService extends EventEmitter2 implements IMessageBusServi
       }
 
       this.subscriptions[channel][subscriptionIndex].fayeSubscription.cancel();
-      delete this.subscriptions[channel][subscriptionIndex];
+      this.subscriptions[channel].splice(subscriptionIndex, 1);
     });
   }
 
@@ -99,6 +99,7 @@ export class MessageBusService extends EventEmitter2 implements IMessageBusServi
           subscription.fayeSubscription.cancel();
         }
 
+        console.log(`mapping ${subscription.callback.toString()}`);
         const newSubscription: SubscriptionObject = this.fayeClient.subscribe(channel).withChannel(subscription.callback);
         this.subscriptions[channel].push({
           fayeSubscription: newSubscription,


### PR DESCRIPTION
## What did you change?

When unsubscribing from a channel, the subscription was [deleted instead of spliced](https://github.com/process-engine/consumer_client/blob/10da68c694d67d8ef1cb5d36f69ae4a71d105603/src/faye.ts#L84). This resulted in the element in the array being replaced with `empty`, instead of removing the entry.

<img width="218" alt="bildschirmfoto 2017-12-19 um 12 10 15" src="https://user-images.githubusercontent.com/20770029/34154843-3f670f06-e4b7-11e7-93d4-ea3820d47660.png">

This in turn would result in the following error when trying to update the consumerClient-config:

```
Cannot read property 'fayeSubscription' of undefiend
```
<img width="600" alt="bildschirmfoto 2017-12-19 um 10 57 20" src="https://user-images.githubusercontent.com/20770029/34154477-ee5e837e-e4b5-11e7-9312-8f309c927cf3.png">

This PR ist required for https://github.com/process-engine/charon/pull/94

## How can others test the changes?

1. use Charon on the [`feature/config_panel`-branch](https://github.com/process-engine/charon/pull/94)
2. link the consumerClient on the develop-branch into it
3. build the consumerClient and charon
4. start charon
5. execute any process *and finish it!*
6. go to the config-panel
7. klick `save` and see how the error pops up in the console.
8. switch the consumerClient to the `feature/fix_configupdate_after_unsubscribe`-branch
9. repeat steps 3-6
10. klick `save` and see how the error no longer appeares

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
